### PR TITLE
删除 Moji 词典请求中的多余信息，以修复session expired错误

### DIFF
--- a/Moji-fast.py
+++ b/Moji-fast.py
@@ -36,34 +36,26 @@ class Moji(WebService):#接口名称
         'searchText':"",
         "needWords": True,
         "langEnv": "zh-CN_ja",
-        "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b",
         "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
-        "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a",
         "_ClientVersion": "js2.12.0",
     }
 
     word_data={#单词详细数据
         "wordId": '', 
-        "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b", 
-        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p", 
-        "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a", 
+        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
         "_ClientVersion": "js2.12.0",
     }
 
     word_tts={#这个是例句的
         "tarId":"",
         "tarType":103,
-        "_SessionToken":"r:610f6ba0d8d2721e773a2b185b85590b",
         "_ApplicationId":"E62VyFVLMiW7kvbtVq3p",
-        "_InstallationId":"5562c88b-b67a-c285-b9d1-a8360121380a",
         "_ClientVersion":"js2.12.0"
     }
     tts_data={#这个是单词的
         "tarId": '', 
         "tarType": 102, 
-        "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b", 
-        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p", 
-        "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a", 
+        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
         "_ClientVersion": "js2.12.0"
     }
     def __init__(self):

--- a/moji.py
+++ b/moji.py
@@ -13,34 +13,26 @@ data={#单词列表
 	'searchText':"",
 	"needWords": True,
 	"langEnv": "zh-CN_ja",
-	"_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b",
 	"_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
-	"_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a",
 	"_ClientVersion": "js2.12.0",
 }
 
 word_data={#单词详细数据
     "wordId": '', 
-    "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b", 
-    "_ApplicationId": "E62VyFVLMiW7kvbtVq3p", 
-    "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a", 
+    "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
     "_ClientVersion": "js2.12.0",
 }
 
 word_tts={#这个是例句的
     "tarId":"",
     "tarType":103,
-    "_SessionToken":"r:610f6ba0d8d2721e773a2b185b85590b",
     "_ApplicationId":"E62VyFVLMiW7kvbtVq3p",
-    "_InstallationId":"5562c88b-b67a-c285-b9d1-a8360121380a",
     "_ClientVersion":"js2.12.0"
 }
 tts_data={#这个是单词的
     "tarId": '', 
     "tarType": 102, 
-    "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b", 
-    "_ApplicationId": "E62VyFVLMiW7kvbtVq3p", 
-    "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a", 
+    "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
     "_ClientVersion": "js2.12.0"
 }
 data['searchText'] = "ひとたび"

--- a/moji_回退前.py
+++ b/moji_回退前.py
@@ -16,9 +16,7 @@ class Moji(object):
     tts_data={#这个是单词的,102单词,103例句
         "tarId": '', 
         "tarType": 102, 
-        "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b", 
-        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p", 
-        "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a", 
+        "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
         "_ClientVersion": "js2.12.0"
     }
     
@@ -27,18 +25,14 @@ class Moji(object):
         'searchText':"",
         "needWords": True,
         "langEnv": "zh-CN_ja",
-        "_SessionToken": "r:610f6ba0d8d2721e773a2b185b85590b",
         "_ApplicationId": "E62VyFVLMiW7kvbtVq3p",
-        "_InstallationId": "5562c88b-b67a-c285-b9d1-a8360121380a",
         "_ClientVersion": "js2.12.0",
     }
 
     target_fetch = 'https://api.mojidict.com/parse/functions/fetchWord_v2'#查询单词详细内容
     word_data={#单词详细数据
     "wordId":"",
-    "_SessionToken":"r:610f6ba0d8d2721e773a2b185b85590b",
     "_ApplicationId":"E62VyFVLMiW7kvbtVq3p",
-    "_InstallationId":"5562c88b-b67a-c285-b9d1-a8360121380a",
     "_ClientVersion":"js2.12.0"
     }
     def Post_Word(self):


### PR DESCRIPTION
发现 Moji 的请求头中只需保留`_ApplicationId`和`_ClientVersion`就可进行查询，因此删除`_SessionToken`和`_InstallationId` 来解决token过期错误。